### PR TITLE
Updates to the Relative Abundance shiny app

### DIFF
--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -125,7 +125,7 @@ shinyServer(function(input, output, session) {
     
     taxon_level <- input$taxonLevel
     if(!identical(taxon_level, "")){
-      # output$overviewDatatable <- renderDataTable(NULL)
+      
       global_otus <<- mstudy$get_otus_by_level(taxon_level)
       selected_levels <<- get_columns_taxonomy(taxon_level)
       
@@ -153,101 +153,6 @@ shinyServer(function(input, output, session) {
     }
   }, ignoreNULL = TRUE, ignoreInit = TRUE)
   
-#  overviewChart <- function(){}
-#  
-#  output$overviewChart <- renderUI({
-#    mstudy <- load_microbiome_data()
-#    category<-input$category
-#    taxon_level<-input$taxonLevel
-#    result_to_show<-NULL
-#    if(!identical(input$category, "")){
-#      shinyjs::hide("divContent")
-#      shinyjs::show("chartLoading")
-#      quantity_samples <- mstudy$get_sample_count()
-#      #TODO test for input without 10 different taxa
-#      top_ten<-mstudy$get_top_n_by_mean(taxon_level, NUMBER_TAXA)
-#      ordered<-c(mstudy$otu_table$get_ordered_otu(NUMBER_TAXA))
-#      rev_ordered<-c("Other", rev(ordered))
-#      wrapped_labels<-wrap_column(rev_ordered)
-#      top_ten[[taxon_level]]<-factor(top_ten[[taxon_level]], levels=rev_ordered)
-#      if(identical(category, NO_METADATA_SELECTED)){
-#        chart<-ggplot(top_ten, aes_string(x="SampleName", y="Abundance", fill=taxon_level))+
-#          geom_bar(stat="identity", position="stack", color="black")+
-#          theme_eupath_default(
-#            legend.title.align=0.4,
-#            legend.title = element_text(colour="black", size=rel(1), face="bold"),
-#            axis.text.y=element_blank(),
-#            axis.ticks.y = element_blank()
-#          )+
-#          scale_fill_manual(values=eupath_pallete, name=taxon_level,
-#                            labels = c(wrapped_labels),
-#                            guide = guide_legend(reverse=TRUE, keywidth = 1.7, keyheight = 1.7)
-#                          )+
-#          labs(x="Samples", y="Phylogenetic Relative Abundance")+
-#          coord_flip(expand=F)
-#      }else{
-#        dt_metadata<-mstudy$get_metadata_as_column(category)
-#        dt_metadata<-merge(dt_metadata, top_ten, by="SampleName")
-#      
-#        #colnames(dt_metadata)[2] <- make.names(category)
-#        col_renamed <- make.names(category)
-#        all_columns <- colnames(dt_metadata)
-#        all_columns[2]<-col_renamed
-#        colnames(dt_metadata)<-all_columns
-#        
-#        #check for numeric category and bin
-#        #TODO figure how this handles for categorical numeric vars. these should be set to factor before now
-#        if (is.numeric(dt_metadata[[col_renamed]])) {
-#	  if (uniqueN(dt_metadata[[col_renamed]]) > 10) {
-#            dt_metadata[[col_renamed]] <- rcut_number(dt_metadata[[col_renamed]])
-#	  } else {
-#	    dt_metadata[[col_renamed]] <- as.factor(dt_metadata[[col_renamed]])
-#	  }
-#        } else if (is.character(dt_metadata[[col_renamed]])) {
-#          dt_metadata[[col_renamed]] <- factor(dt_metadata[[col_renamed]], levels=mixedsort(levels(as.factor(dt_metadata[[col_renamed]]))))
-#        } 
-#
-#        chart<-ggplot(dt_metadata, aes_string(x="SampleName", y="Abundance", fill=taxon_level))+
-#          geom_bar(stat="identity", position="stack", color="black")+
-#	  facet_wrap(as.formula(paste("~ ",col_renamed)), ncol=1, scales='free_y')+
-#          #facet_grid(rows = col_renamed, scales='free_y', space='free_y')+
-#	  theme(panel.spacing = unit(-.85, "lines")) +
-#          theme_eupath_default(
-#            legend.title.align=0.4,
-#            legend.title = element_text(colour="black", size=rel(1), face="bold"),
-#            axis.text.y=element_blank(),
-#            axis.ticks.y = element_blank()
-#          )+
-#          scale_fill_manual(values=eupath_pallete, name=taxon_level,
-#                            labels = c(wrapped_labels),
-#                            guide = guide_legend(reverse=TRUE, keywidth = 1.7, keyheight = 1.7)
-#          )+
-#          labs(x="Samples", y="Phylogenetic Relative Abundance")+
-#          coord_flip(expand=F)
-#      }
-#      
-#      ggplot_object<<-chart
-#      ggplot_build_object<<-ggplot_build(chart)
-#
-#      output$plotWrapper<-renderPlotly({
-#        ggplotly(chart) %>% plotly:::config(displaylogo = FALSE)
-#      })
-#      
-#      if(quantity_samples<MAX_SAMPLES_NO_RESIZE){
-#        result_to_show<-plotlyOutput("plotWrapper",
-#               width = paste0(WIDTH,"px"), height = "500px"
-#             )
-#      }else{
-#        result_to_show<-plotlyOutput("plotWrapper",
-#           height = quantity_samples*MIN_HEIGHT_AFTER_RESIZE
-#         )
-#      }
-#      shinyjs::hide("chartLoading", anim = TRUE, animType = "slide")
-#      shinyjs::show("divContent")
-#    }
-#    result_to_show
-#  })
-#  
 
   topAbundance <- function(){}
 
@@ -334,7 +239,6 @@ shinyServer(function(input, output, session) {
           colnames(data_frame_table)<-c(taxon_level, "W", "P-Value")
           
 	  data_frame_table[, 3] <- lapply(data_frame_table[, 3], round, 3)
-          # data_frame_table[,3]<-format(data_frame_table[,3], scientific = F)
           
           sketch <- tags$table(
             tags$thead(
@@ -366,7 +270,6 @@ shinyServer(function(input, output, session) {
           }
           colnames(data_frame_table)<-c(taxon_level, "chi-squared", "df", "P-Value")
           data_frame_table[, c(2,4)] <- lapply(data_frame_table[, c(2,4)], round, 3)
-	  # data_frame_table[,4]<-format(data_frame_table[,4], scientific = F)
           
           sketch <- tags$table(
             tags$thead(

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -125,7 +125,7 @@ shinyServer(function(input, output, session) {
     
     taxon_level <- input$taxonLevel
     if(!identical(taxon_level, "")){
-      output$overviewDatatable <- renderDataTable(NULL)
+      # output$overviewDatatable <- renderDataTable(NULL)
       global_otus <<- mstudy$get_otus_by_level(taxon_level)
       selected_levels <<- get_columns_taxonomy(taxon_level)
       
@@ -153,101 +153,101 @@ shinyServer(function(input, output, session) {
     }
   }, ignoreNULL = TRUE, ignoreInit = TRUE)
   
-  overviewChart <- function(){}
-  
-  output$overviewChart <- renderUI({
-    mstudy <- load_microbiome_data()
-    category<-input$category
-    taxon_level<-input$taxonLevel
-    result_to_show<-NULL
-    if(!identical(input$category, "")){
-      shinyjs::hide("divContent")
-      shinyjs::show("chartLoading")
-      quantity_samples <- mstudy$get_sample_count()
-      #TODO test for input without 10 different taxa
-      top_ten<-mstudy$get_top_n_by_mean(taxon_level, NUMBER_TAXA)
-      ordered<-c(mstudy$otu_table$get_ordered_otu(NUMBER_TAXA))
-      rev_ordered<-c("Other", rev(ordered))
-      wrapped_labels<-wrap_column(rev_ordered)
-      top_ten[[taxon_level]]<-factor(top_ten[[taxon_level]], levels=rev_ordered)
-      if(identical(category, NO_METADATA_SELECTED)){
-        chart<-ggplot(top_ten, aes_string(x="SampleName", y="Abundance", fill=taxon_level))+
-          geom_bar(stat="identity", position="stack", color="black")+
-          theme_eupath_default(
-            legend.title.align=0.4,
-            legend.title = element_text(colour="black", size=rel(1), face="bold"),
-            axis.text.y=element_blank(),
-            axis.ticks.y = element_blank()
-          )+
-          scale_fill_manual(values=eupath_pallete, name=taxon_level,
-                            labels = c(wrapped_labels),
-                            guide = guide_legend(reverse=TRUE, keywidth = 1.7, keyheight = 1.7)
-                          )+
-          labs(x="Samples", y="Phylogenetic Relative Abundance")+
-          coord_flip(expand=F)
-      }else{
-        dt_metadata<-mstudy$get_metadata_as_column(category)
-        dt_metadata<-merge(dt_metadata, top_ten, by="SampleName")
-      
-        #colnames(dt_metadata)[2] <- make.names(category)
-        col_renamed <- make.names(category)
-        all_columns <- colnames(dt_metadata)
-        all_columns[2]<-col_renamed
-        colnames(dt_metadata)<-all_columns
-        
-        #check for numeric category and bin
-        #TODO figure how this handles for categorical numeric vars. these should be set to factor before now
-        if (is.numeric(dt_metadata[[col_renamed]])) {
-	  if (uniqueN(dt_metadata[[col_renamed]]) > 10) {
-            dt_metadata[[col_renamed]] <- rcut_number(dt_metadata[[col_renamed]])
-	  } else {
-	    dt_metadata[[col_renamed]] <- as.factor(dt_metadata[[col_renamed]])
-	  }
-        } else if (is.character(dt_metadata[[col_renamed]])) {
-          dt_metadata[[col_renamed]] <- factor(dt_metadata[[col_renamed]], levels=mixedsort(levels(as.factor(dt_metadata[[col_renamed]]))))
-        } 
-
-        chart<-ggplot(dt_metadata, aes_string(x="SampleName", y="Abundance", fill=taxon_level))+
-          geom_bar(stat="identity", position="stack", color="black")+
-	  facet_wrap(as.formula(paste("~ ",col_renamed)), ncol=1, scales='free_y')+
-          #facet_grid(rows = col_renamed, scales='free_y', space='free_y')+
-	  theme(panel.spacing = unit(-.85, "lines")) +
-          theme_eupath_default(
-            legend.title.align=0.4,
-            legend.title = element_text(colour="black", size=rel(1), face="bold"),
-            axis.text.y=element_blank(),
-            axis.ticks.y = element_blank()
-          )+
-          scale_fill_manual(values=eupath_pallete, name=taxon_level,
-                            labels = c(wrapped_labels),
-                            guide = guide_legend(reverse=TRUE, keywidth = 1.7, keyheight = 1.7)
-          )+
-          labs(x="Samples", y="Phylogenetic Relative Abundance")+
-          coord_flip(expand=F)
-      }
-      
-      ggplot_object<<-chart
-      ggplot_build_object<<-ggplot_build(chart)
-
-      output$plotWrapper<-renderPlotly({
-        ggplotly(chart) %>% plotly:::config(displaylogo = FALSE)
-      })
-      
-      if(quantity_samples<MAX_SAMPLES_NO_RESIZE){
-        result_to_show<-plotlyOutput("plotWrapper",
-               width = paste0(WIDTH,"px"), height = "500px"
-             )
-      }else{
-        result_to_show<-plotlyOutput("plotWrapper",
-           height = quantity_samples*MIN_HEIGHT_AFTER_RESIZE
-         )
-      }
-      shinyjs::hide("chartLoading", anim = TRUE, animType = "slide")
-      shinyjs::show("divContent")
-    }
-    result_to_show
-  })
-  
+#  overviewChart <- function(){}
+#  
+#  output$overviewChart <- renderUI({
+#    mstudy <- load_microbiome_data()
+#    category<-input$category
+#    taxon_level<-input$taxonLevel
+#    result_to_show<-NULL
+#    if(!identical(input$category, "")){
+#      shinyjs::hide("divContent")
+#      shinyjs::show("chartLoading")
+#      quantity_samples <- mstudy$get_sample_count()
+#      #TODO test for input without 10 different taxa
+#      top_ten<-mstudy$get_top_n_by_mean(taxon_level, NUMBER_TAXA)
+#      ordered<-c(mstudy$otu_table$get_ordered_otu(NUMBER_TAXA))
+#      rev_ordered<-c("Other", rev(ordered))
+#      wrapped_labels<-wrap_column(rev_ordered)
+#      top_ten[[taxon_level]]<-factor(top_ten[[taxon_level]], levels=rev_ordered)
+#      if(identical(category, NO_METADATA_SELECTED)){
+#        chart<-ggplot(top_ten, aes_string(x="SampleName", y="Abundance", fill=taxon_level))+
+#          geom_bar(stat="identity", position="stack", color="black")+
+#          theme_eupath_default(
+#            legend.title.align=0.4,
+#            legend.title = element_text(colour="black", size=rel(1), face="bold"),
+#            axis.text.y=element_blank(),
+#            axis.ticks.y = element_blank()
+#          )+
+#          scale_fill_manual(values=eupath_pallete, name=taxon_level,
+#                            labels = c(wrapped_labels),
+#                            guide = guide_legend(reverse=TRUE, keywidth = 1.7, keyheight = 1.7)
+#                          )+
+#          labs(x="Samples", y="Phylogenetic Relative Abundance")+
+#          coord_flip(expand=F)
+#      }else{
+#        dt_metadata<-mstudy$get_metadata_as_column(category)
+#        dt_metadata<-merge(dt_metadata, top_ten, by="SampleName")
+#      
+#        #colnames(dt_metadata)[2] <- make.names(category)
+#        col_renamed <- make.names(category)
+#        all_columns <- colnames(dt_metadata)
+#        all_columns[2]<-col_renamed
+#        colnames(dt_metadata)<-all_columns
+#        
+#        #check for numeric category and bin
+#        #TODO figure how this handles for categorical numeric vars. these should be set to factor before now
+#        if (is.numeric(dt_metadata[[col_renamed]])) {
+#	  if (uniqueN(dt_metadata[[col_renamed]]) > 10) {
+#            dt_metadata[[col_renamed]] <- rcut_number(dt_metadata[[col_renamed]])
+#	  } else {
+#	    dt_metadata[[col_renamed]] <- as.factor(dt_metadata[[col_renamed]])
+#	  }
+#        } else if (is.character(dt_metadata[[col_renamed]])) {
+#          dt_metadata[[col_renamed]] <- factor(dt_metadata[[col_renamed]], levels=mixedsort(levels(as.factor(dt_metadata[[col_renamed]]))))
+#        } 
+#
+#        chart<-ggplot(dt_metadata, aes_string(x="SampleName", y="Abundance", fill=taxon_level))+
+#          geom_bar(stat="identity", position="stack", color="black")+
+#	  facet_wrap(as.formula(paste("~ ",col_renamed)), ncol=1, scales='free_y')+
+#          #facet_grid(rows = col_renamed, scales='free_y', space='free_y')+
+#	  theme(panel.spacing = unit(-.85, "lines")) +
+#          theme_eupath_default(
+#            legend.title.align=0.4,
+#            legend.title = element_text(colour="black", size=rel(1), face="bold"),
+#            axis.text.y=element_blank(),
+#            axis.ticks.y = element_blank()
+#          )+
+#          scale_fill_manual(values=eupath_pallete, name=taxon_level,
+#                            labels = c(wrapped_labels),
+#                            guide = guide_legend(reverse=TRUE, keywidth = 1.7, keyheight = 1.7)
+#          )+
+#          labs(x="Samples", y="Phylogenetic Relative Abundance")+
+#          coord_flip(expand=F)
+#      }
+#      
+#      ggplot_object<<-chart
+#      ggplot_build_object<<-ggplot_build(chart)
+#
+#      output$plotWrapper<-renderPlotly({
+#        ggplotly(chart) %>% plotly:::config(displaylogo = FALSE)
+#      })
+#      
+#      if(quantity_samples<MAX_SAMPLES_NO_RESIZE){
+#        result_to_show<-plotlyOutput("plotWrapper",
+#               width = paste0(WIDTH,"px"), height = "500px"
+#             )
+#      }else{
+#        result_to_show<-plotlyOutput("plotWrapper",
+#           height = quantity_samples*MIN_HEIGHT_AFTER_RESIZE
+#         )
+#      }
+#      shinyjs::hide("chartLoading", anim = TRUE, animType = "slide")
+#      shinyjs::show("divContent")
+#    }
+#    result_to_show
+#  })
+#  
 
   topAbundance <- function(){}
 

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -238,7 +238,7 @@ shinyServer(function(input, output, session) {
           }
           colnames(data_frame_table)<-c(taxon_level, "W", "P-Value")
           
-	  data_frame_table[, 3] <- lapply(data_frame_table[, 3], round, 3)
+	  data_frame_table[, 3] <- round(data_frame_table[, 3], 3)
           
           sketch <- tags$table(
             tags$thead(
@@ -269,7 +269,7 @@ shinyServer(function(input, output, session) {
             data_frame_table<-rbind(data_frame_table, df)
           }
           colnames(data_frame_table)<-c(taxon_level, "chi-squared", "df", "P-Value")
-          data_frame_table[, c(2,4)] <- lapply(data_frame_table[, c(2,4)], round, 3)
+          data_frame_table[, c(2,4)] <- round(data_frame_table[, c(2,4)], 3)
           
           sketch <- tags$table(
             tags$thead(

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -333,7 +333,8 @@ shinyServer(function(input, output, session) {
           }
           colnames(data_frame_table)<-c(taxon_level, "W", "P-Value")
           
-          data_frame_table[,3]<-format(data_frame_table[,3], scientific = F)
+	  data_frame_table[, 3] <- lapply(data_frame_table[, 3], round, 3)
+          # data_frame_table[,3]<-format(data_frame_table[,3], scientific = F)
           
           sketch <- tags$table(
             tags$thead(
@@ -364,7 +365,8 @@ shinyServer(function(input, output, session) {
             data_frame_table<-rbind(data_frame_table, df)
           }
           colnames(data_frame_table)<-c(taxon_level, "chi-squared", "df", "P-Value")
-          data_frame_table[,4]<-format(data_frame_table[,4], scientific = F)
+          data_frame_table[, c(2,4)] <- lapply(data_frame_table[, c(2,4)], round, 3)
+	  # data_frame_table[,4]<-format(data_frame_table[,4], scientific = F)
           
           sketch <- tags$table(
             tags$thead(

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -130,7 +130,7 @@ shinyServer(function(input, output, session) {
       selected_levels <<- get_columns_taxonomy(taxon_level)
       
       hash_colors <<- eupath_pallete
-      top_ten<-mstudy$get_top_n_by_mean(taxon_level, NUMBER_TAXA)
+      top_ten<-mstudy$get_top_n_by_median(taxon_level, NUMBER_TAXA)
       ordered<-c(mstudy$otu_table$get_ordered_otu(NUMBER_TAXA))
       rev_ordered<-c("Other", rev(ordered))
       names(hash_colors) <<- rev_ordered
@@ -265,7 +265,7 @@ shinyServer(function(input, output, session) {
       
       quantity_samples <- mstudy$get_sample_count()
       
-      top_ten<-mstudy$get_top_n_by_mean(taxonomy_level = taxon_level, n = NUMBER_TAXA, 
+      top_ten<-mstudy$get_top_n_by_median(taxonomy_level = taxon_level, n = NUMBER_TAXA, 
                                         add_other = F)
       
       ordered<-mstudy$otu_table$get_ordered_otu(NUMBER_TAXA)

--- a/View/lib/R/shiny/apps/abundance_app/ui.R
+++ b/View/lib/R/shiny/apps/abundance_app/ui.R
@@ -91,31 +91,31 @@ shinyUI(
              )
            )
          ),# end tabPabel byTopOTU
-         tabPanel(
-           id="firstTab",
-           title = "Overview",
-           value = "bySample",
-           hidden(
-             div(id="chartLoading", style="text-align: center;",
-                 h5("Formatting plot..."),
-                 img(src = "spinner.gif", id = "loading-spinner")
-             )),
-           div(
-             id="overviewTabContent",
-               fluidRow(column(
-                 12,
-                 div(style = "position:relative",
-                     # div(onclick="shinyjs.newScrollTo('div_sample_datatable')",
-                       uiOutput("overviewChart"),
-                       # ),
-                     uiOutput("overviewTooltip"))
-               )),
-               fluidRow(column(
-                 12,
-                   dataTableOutput("overviewDatatable")
-               ))
-           )
-         ), # end tabPanel bySample
+        # tabPanel(
+        #   id="firstTab",
+        #   title = "Overview",
+        #   value = "bySample",
+        #   hidden(
+        #     div(id="chartLoading", style="text-align: center;",
+        #         h5("Formatting plot..."),
+        #         img(src = "spinner.gif", id = "loading-spinner")
+        #     )),
+        #   div(
+        #     id="overviewTabContent",
+        #       fluidRow(column(
+        #         12,
+        #         div(style = "position:relative",
+        #             # div(onclick="shinyjs.newScrollTo('div_sample_datatable')",
+        #               uiOutput("overviewChart"),
+        #               # ),
+        #             uiOutput("overviewTooltip"))
+        #       )),
+        #       fluidRow(column(
+        #         12,
+        #           dataTableOutput("overviewDatatable")
+        #       ))
+        #   )
+        # ), # end tabPanel bySample
          tabPanel(
            title = "Single Taxon",
            value = "byOTU",

--- a/View/lib/R/shiny/apps/abundance_app/ui.R
+++ b/View/lib/R/shiny/apps/abundance_app/ui.R
@@ -91,31 +91,6 @@ shinyUI(
              )
            )
          ),# end tabPabel byTopOTU
-        # tabPanel(
-        #   id="firstTab",
-        #   title = "Overview",
-        #   value = "bySample",
-        #   hidden(
-        #     div(id="chartLoading", style="text-align: center;",
-        #         h5("Formatting plot..."),
-        #         img(src = "spinner.gif", id = "loading-spinner")
-        #     )),
-        #   div(
-        #     id="overviewTabContent",
-        #       fluidRow(column(
-        #         12,
-        #         div(style = "position:relative",
-        #             # div(onclick="shinyjs.newScrollTo('div_sample_datatable')",
-        #               uiOutput("overviewChart"),
-        #               # ),
-        #             uiOutput("overviewTooltip"))
-        #       )),
-        #       fluidRow(column(
-        #         12,
-        #           dataTableOutput("overviewDatatable")
-        #       ))
-        #   )
-        # ), # end tabPanel bySample
          tabPanel(
            title = "Single Taxon",
            value = "byOTU",

--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -63,7 +63,7 @@ shinyServer(function(input, output, session) {
 
     }
 
-    otus<-mstudy_obj$get_otus_by_level(input$taxonLevel)
+    
     cor_type<-input$corType
     taxon_level<-input$taxonLevel
     if(identical(cor_type, "tm")){

--- a/View/lib/R/shiny/lib/mbiome/mbiome-data.R
+++ b/View/lib/R/shiny/lib/mbiome/mbiome-data.R
@@ -63,8 +63,8 @@ MicrobiomeData <- R6Class("MicrobiomeData",
          get_otus_by_level = function(taxonomy_level=NULL){
            self$otu_table$get_otus_by_level(taxonomy_level)
          },
-         get_top_n_by_mean = function(taxonomy_level=NULL, n=10, add_other=T){
-            self$otu_table$get_top_n_by_mean(taxonomy_level, n, add_other)
+         get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T){
+            self$otu_table$get_top_n_by_median(taxonomy_level, n, add_other)
          },
          get_single_otu = function(taxonomy_level=NULL, otu_name, add_other=F, keep_all=F){
            self$otu_table$get_single_otu(taxonomy_level, otu_name, add_other, keep_all)

--- a/View/lib/R/shiny/lib/mbiome/mbiome-data.R
+++ b/View/lib/R/shiny/lib/mbiome/mbiome-data.R
@@ -66,6 +66,9 @@ MicrobiomeData <- R6Class("MicrobiomeData",
          get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T){
             self$otu_table$get_top_n_by_median(taxonomy_level, n, add_other)
          },
+         get_top_n_by_mean = function(taxonomy_level=NULL, n=10, add_other=T){
+            self$otu_table$get_top_n_by_mean(taxonomy_level, n, add_other)
+         },
          get_single_otu = function(taxonomy_level=NULL, otu_name, add_other=F, keep_all=F){
            self$otu_table$get_single_otu(taxonomy_level, otu_name, add_other, keep_all)
          }

--- a/View/lib/R/shiny/lib/mbiome/otu-table.R
+++ b/View/lib/R/shiny/lib/mbiome/otu-table.R
@@ -1,7 +1,7 @@
 OTUClass <- R6Class("OTUClass",
     private = list(
       summarized_otu = NULL,
-      summarized_means = NULL,
+      summarized_medians = NULL,
       last_taxonomy = "",
       use_relative_abundance = T,
       ordered_n_otu = NULL,
@@ -55,10 +55,10 @@ OTUClass <- R6Class("OTUClass",
         # end of workaroud for perfomance
         colnames(private$summarized_otu)<-c("SampleName", selected_levels, "Abundance")
 
-        private$summarized_means<-private$summarized_otu[,list(Abundance=mean(Abundance)), by=taxonomy_level]
+        private$summarized_medians<-private$summarized_otu[,list(Abundance=median(Abundance)), by=taxonomy_level]
 
-        setorderv(private$summarized_means, c("Abundance", taxonomy_level), c(-1,rep(1,length(taxonomy_level))))
-        private$ordered_all_otu <- private$summarized_means[[taxonomy_level]]
+        setorderv(private$summarized_medians, c("Abundance", taxonomy_level), c(-1,rep(1,length(taxonomy_level))))
+        private$ordered_all_otu <- private$summarized_medians[[taxonomy_level]]
 
         self
       },
@@ -113,7 +113,7 @@ OTUClass <- R6Class("OTUClass",
           private$ordered_all_otu
         }else{
           if(n != length(private$ordered_n_otu)){
-            top_n <- head(private$summarized_means, n)
+            top_n <- head(private$summarized_medians, n)
             private$ordered_n_otu <- top_n[[private$last_taxonomy]]
           }
           private$ordered_n_otu
@@ -128,12 +128,12 @@ OTUClass <- R6Class("OTUClass",
         }
       },
 
-      get_top_n_by_mean = function(taxonomy_level=NULL, n=10, add_other=T){
+      get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T){
         if(!is.null(taxonomy_level) & !identical(taxonomy_level, private$last_taxonomy)){
           self$reshape(taxonomy_level = taxonomy_level)
         }
 
-        top_n <- head(private$summarized_means, n)
+        top_n <- head(private$summarized_medians, n)
         top_n$Abundance<-format(top_n$Abundance, scientific = F)
         private$ordered_n_otu <- top_n[[private$last_taxonomy]]
 


### PR DESCRIPTION
This PR includes three updates to the current Relative Abundance shiny app. 

1. Removed "Overview" tab.
2. Table now displays only 3 decimal places.
3. Top ten now ranked by median instead of mean.

*Details*

1. Related code deleted in `ui.R` and `server.R`.
2. Computed p-values are naturally viewed in scientific notation, but the original code formatted these numbers to decimal notation. This conversion also converted p-values to strings, which was not easily compatible with rounding decimals. The new code removes the scientific formatting step and replaces it with the `round` function which rounds the p-values to three decimal places.
3. The culprit here was the `get_top_n_by_mean` function which relied on the `summarized_means` property of data object. After checking that no other apps rely on `summarized_means`, the proposed code changes this property to `summarized_medians`. There was one reference of a dependent function in the correlation app, but it was unused so was removed. All other references of "mean" were replaced with "median", when appropriate.