### PR TITLE
fIx: dropped taxa with median=0 from box plot

### DIFF
--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -130,7 +130,7 @@ shinyServer(function(input, output, session) {
       
       # hash_colors <<- eupath_pallete
       top_ten<-mstudy$get_top_n_by_median(taxon_level, NUMBER_TAXA, removeZeros = T)
-      number_taxa_no_zeros <- length(unique(top_ten[[taxon_level]]))
+      number_taxa_no_zeros <- uniqueN(top_ten[[taxon_level]])
 
       ordered<-c(mstudy$otu_table$get_ordered_otu(number_taxa_no_zeros))
       rev_ordered<-c("Other", rev(ordered))
@@ -174,7 +174,7 @@ shinyServer(function(input, output, session) {
 top_ten<-mstudy$get_top_n_by_median(taxonomy_level = taxon_level, n = NUMBER_TAXA, 
                                         add_other = F, removeZeros = T)
       if(nrow(top_ten>0)){
-        number_taxa_no_zeros <- length(unique(top_ten[[taxon_level]]))
+        number_taxa_no_zeros <- uniqueN(top_ten[[taxon_level]])
 
         ordered<-mstudy$otu_table$get_ordered_otu(number_taxa_no_zeros)
     

--- a/View/lib/R/shiny/lib/mbiome/mbiome-data.R
+++ b/View/lib/R/shiny/lib/mbiome/mbiome-data.R
@@ -63,8 +63,8 @@ MicrobiomeData <- R6Class("MicrobiomeData",
          get_otus_by_level = function(taxonomy_level=NULL){
            self$otu_table$get_otus_by_level(taxonomy_level)
          },
-         get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T){
-            self$otu_table$get_top_n_by_median(taxonomy_level, n, add_other)
+         get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T, removeZeros=F){
+            self$otu_table$get_top_n_by_median(taxonomy_level, n, add_other, removeZeros)
          },
          get_top_n_by_mean = function(taxonomy_level=NULL, n=10, add_other=T){
             self$otu_table$get_top_n_by_mean(taxonomy_level, n, add_other)

--- a/View/lib/R/shiny/lib/mbiome/otu-table.R
+++ b/View/lib/R/shiny/lib/mbiome/otu-table.R
@@ -132,12 +132,17 @@ OTUClass <- R6Class("OTUClass",
         }
       },
 
-      get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T){
+      get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T, removeZeros=F){
         if(!is.null(taxonomy_level) & !identical(taxonomy_level, private$last_taxonomy)){
           self$reshape(taxonomy_level = taxonomy_level)
         }
 
         top_n <- head(private$summarized_medians, n)
+
+        if(removeZeros) {
+          top_n <- top_n[Abundance>0, ]
+        }
+
         top_n$Abundance<-format(top_n$Abundance, scientific = F)
         private$ordered_n_otu <- top_n[[private$last_taxonomy]]
 


### PR DESCRIPTION
In the previous release, we ordered taxa by median abundance in the box plots but then found (thanks to Wojtek) that the code ranks ties in median abundance alphabetically. Ties are pretty common because many taxa have median abundance =0. 

This PR addresses the issue by adding a `removeZeros` argument to the `get_top_n_by_median` function with default `F`. For the relative abundance app, we set `removeZeros=T`, so that only those taxa with median abundance > 0 are shown. If no taxa meet this criteria, a new warning appears on the plot to inform the user.



