### PR TITLE
Fix - Offer taxa ranking options

### DIFF
--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -167,6 +167,7 @@ shinyServer(function(input, output, session) {
     if(!identical(category, "")){
       
       shinyjs::hide("topTabContent")
+      shinyjs::hide(id="helpText")
       shinyjs::show("topTabLoading")
       
       quantity_samples <- mstudy$get_sample_count()
@@ -317,6 +318,13 @@ top_ten<-mstudy$get_top_n_by_median(taxonomy_level = taxon_level, n = NUMBER_TAX
         
         shinyjs::hide("topTabLoading", anim = TRUE, animType = "slide")
         shinyjs::show("topTabContent")
+        
+        # Show help text only if no metadata is selected and ensure table doesn't show
+        if(identical(category, NO_METADATA_SELECTED)){
+          shinyjs::show(id="helpText")
+          output$by_top_otu_datatable <- NULL
+        }
+
       } else {
       logjs("No OUTPUT")
         shinyjs::hide("topTabLoading", anim = TRUE, animType = "slide")
@@ -355,6 +363,7 @@ top_ten<-mstudy$get_top_n_by_median(taxonomy_level = taxon_level, n = NUMBER_TAX
     
     if(!identical(category, "") & !identical(otu_picked, "") & !identical(taxon_level,"")){
       shinyjs::hide("singleOtuContent")
+      shinyjs::hide(id="helpText")
       shinyjs::show("singleOtuLoading")
       
       quantity_samples <- mstudy$get_sample_count()

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -380,7 +380,6 @@ shinyServer(function(input, output, session) {
         shinyjs::hide("topTabLoading", anim = TRUE, animType = "slide")
         shinyjs::show("topTabContent")
         
-        # Show help text only if no metadata is selected and ensure table doesn't show
         if(identical(category, NO_METADATA_SELECTED)){
           output$by_top_otu_datatable <- NULL
         }

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -485,7 +485,7 @@ shinyServer(function(input, output, session) {
         merged_to_stats<-merge(metadata_as_column, otu_data, by="SampleName", all=T)
         
         chart<-ggplot(merged_to_plot, aes_string(x=col_renamed, y="Abundance"))+geom_boxplot()+
-          theme_eupath_default()+
+          theme_eupath_default(axis.text.x = element_text(angle = 45, hjust = 1))+
           labs(x=stringi::stri_trans_totitle(category), y=paste(otu_picked, "Relative Abundance"))
         
         output$singleOtuPlotWrapper<-renderPlotly({

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -129,7 +129,7 @@ shinyServer(function(input, output, session) {
       selected_levels <<- get_columns_taxonomy(taxon_level)
       
       # hash_colors <<- eupath_pallete
-      top_ten<-mstudy$get_top_n_by_median(taxon_level, NUMBER_TAXA, removeZeros = T)
+      top_ten<-mstudy$get_top_n_by_median(taxon_level, NUMBER_TAXA, removeZeros = F)
       number_taxa_no_zeros <- uniqueN(top_ten[[taxon_level]])
 
       ordered<-c(mstudy$otu_table$get_ordered_otu(number_taxa_no_zeros))
@@ -172,7 +172,7 @@ shinyServer(function(input, output, session) {
       quantity_samples <- mstudy$get_sample_count()
 
 top_ten<-mstudy$get_top_n_by_median(taxonomy_level = taxon_level, n = NUMBER_TAXA, 
-                                        add_other = F, removeZeros = T)
+                                        add_other = F, removeZeros = F)
       if(nrow(top_ten>0)){
         number_taxa_no_zeros <- uniqueN(top_ten[[taxon_level]])
 

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -295,7 +295,7 @@ shinyServer(function(input, output, session) {
             colnames(data_frame_table)<-c(taxon_level, "W", "P-Value")
             
             
-            data_frame_table[, 3] <- lapply(data_frame_table[, 3], round, 3)
+            data_frame_table[, 2:3] <- lapply(data_frame_table[, 2:3], round, 3)
             # Removes scientific formatting of P-values which also converts them to strings. If we round instead, we don't need this step
             
             # data_frame_table[,3]<-format(data_frame_table[,3], scientific = F)

--- a/View/lib/R/shiny/apps/abundance_app/server.R
+++ b/View/lib/R/shiny/apps/abundance_app/server.R
@@ -382,7 +382,6 @@ shinyServer(function(input, output, session) {
         
         # Show help text only if no metadata is selected and ensure table doesn't show
         if(identical(category, NO_METADATA_SELECTED)){
-          shinyjs::show(id="helpText")
           output$by_top_otu_datatable <- NULL
         }
 
@@ -424,7 +423,6 @@ shinyServer(function(input, output, session) {
     
     if(!identical(category, "") & !identical(otu_picked, "") & !identical(taxon_level,"")){
       shinyjs::hide("singleOtuContent")
-      shinyjs::hide(id="helpText")
       shinyjs::show("singleOtuLoading")
       
       quantity_samples <- mstudy$get_sample_count()

--- a/View/lib/R/shiny/apps/abundance_app/ui.R
+++ b/View/lib/R/shiny/apps/abundance_app/ui.R
@@ -28,13 +28,17 @@ shinyUI(
     id = "app-content",
          fluidRow(
            column(
-           3,
+           2,
            uiOutput("taxLevel"),
            # this div is not showed, this is just a workaround to load the files in a reactive environment
            div(style = "display: none;",
                checkboxInput(
                  "taxa_are_rows", label = "", value = T
                ))
+         ),
+         column(
+           2,
+           uiOutput("rankingMethod")
          ),
          column(
            5,
@@ -47,7 +51,7 @@ shinyUI(
            )
          ),
 
-         column(4,
+         column(3,
             div(
               style = "padding-left: 1em;",
               fluidRow(
@@ -75,8 +79,13 @@ shinyUI(
                  h5("Formatting plot..."),
                  img(src = "spinner.gif", id = "loading-spinner")
              )),
-           div(
+            div(
              id="topTabContent",
+            #  fluidRow(
+            #   div(style="text-align: center; margin: auto; padding-top: 10px",
+            #     helpText("Note: taxa are sorted by median, then third quantile, then maximum relative abundance.")
+            #   )
+            #  ),
              fluidRow(
                column(12,
                       # div(style = "position:relative",
@@ -85,17 +94,37 @@ shinyUI(
                       # )
                )),
              fluidRow(
-              div(id="helpText", style="text-align: center; margin: auto; padding: 50px; width: 80%",
-                helpText("Note: taxa are sorted by median, then third quantile, then maximum relative abundance.")
-              )
-             ),
-             fluidRow(
                column(12,
                       DT::dataTableOutput("by_top_otu_datatable")
                )
              )
            )
          ),# end tabPabel byTopOTU
+        # tabPanel(
+        #   id="firstTab",
+        #   title = "Overview",
+        #   value = "bySample",
+        #   hidden(
+        #     div(id="chartLoading", style="text-align: center;",
+        #         h5("Formatting plot..."),
+        #         img(src = "spinner.gif", id = "loading-spinner")
+        #     )),
+        #   div(
+        #     id="overviewTabContent",
+        #       fluidRow(column(
+        #         12,
+        #         div(style = "position:relative",
+        #             # div(onclick="shinyjs.newScrollTo('div_sample_datatable')",
+        #               uiOutput("overviewChart"),
+        #               # ),
+        #             uiOutput("overviewTooltip"))
+        #       )),
+        #       fluidRow(column(
+        #         12,
+        #           dataTableOutput("overviewDatatable")
+        #       ))
+        #   )
+        # ), # end tabPanel bySample
          tabPanel(
            title = "Single Taxon",
            value = "byOTU",
@@ -142,3 +171,4 @@ shinyUI(
     ) # end hidden
   ) # end fluidPage
 ) # end shinyUI
+

--- a/View/lib/R/shiny/apps/abundance_app/ui.R
+++ b/View/lib/R/shiny/apps/abundance_app/ui.R
@@ -81,11 +81,6 @@ shinyUI(
              )),
             div(
              id="topTabContent",
-            #  fluidRow(
-            #   div(style="text-align: center; margin: auto; padding-top: 10px",
-            #     helpText("Note: taxa are sorted by median, then third quantile, then maximum relative abundance.")
-            #   )
-            #  ),
              fluidRow(
                column(12,
                       # div(style = "position:relative",
@@ -100,31 +95,6 @@ shinyUI(
              )
            )
          ),# end tabPabel byTopOTU
-        # tabPanel(
-        #   id="firstTab",
-        #   title = "Overview",
-        #   value = "bySample",
-        #   hidden(
-        #     div(id="chartLoading", style="text-align: center;",
-        #         h5("Formatting plot..."),
-        #         img(src = "spinner.gif", id = "loading-spinner")
-        #     )),
-        #   div(
-        #     id="overviewTabContent",
-        #       fluidRow(column(
-        #         12,
-        #         div(style = "position:relative",
-        #             # div(onclick="shinyjs.newScrollTo('div_sample_datatable')",
-        #               uiOutput("overviewChart"),
-        #               # ),
-        #             uiOutput("overviewTooltip"))
-        #       )),
-        #       fluidRow(column(
-        #         12,
-        #           dataTableOutput("overviewDatatable")
-        #       ))
-        #   )
-        # ), # end tabPanel bySample
          tabPanel(
            title = "Single Taxon",
            value = "byOTU",

--- a/View/lib/R/shiny/apps/abundance_app/ui.R
+++ b/View/lib/R/shiny/apps/abundance_app/ui.R
@@ -78,6 +78,11 @@ shinyUI(
            div(
              id="topTabContent",
              fluidRow(
+              div(style="text-align: center; margin: auto; padding-top: 10px",
+                helpText("Note: taxa are sorted by median, then third quantile, then maximum relative abundance.")
+              )
+             ),
+             fluidRow(
                column(12,
                       # div(style = "position:relative",
                       uiOutput("chartByTopOTU"),

--- a/View/lib/R/shiny/apps/abundance_app/ui.R
+++ b/View/lib/R/shiny/apps/abundance_app/ui.R
@@ -78,17 +78,17 @@ shinyUI(
            div(
              id="topTabContent",
              fluidRow(
-              div(style="text-align: center; margin: auto; padding-top: 10px",
-                helpText("Note: taxa are sorted by median, then third quantile, then maximum relative abundance.")
-              )
-             ),
-             fluidRow(
                column(12,
                       # div(style = "position:relative",
                       uiOutput("chartByTopOTU"),
                       uiOutput("hoverByTopOTU")
                       # )
                )),
+             fluidRow(
+              div(id="helpText", style="text-align: center; margin: auto; padding: 50px; width: 80%",
+                helpText("Note: taxa are sorted by median, then third quantile, then maximum relative abundance.")
+              )
+             ),
              fluidRow(
                column(12,
                       DT::dataTableOutput("by_top_otu_datatable")

--- a/View/lib/R/shiny/lib/mbiome/mbiome-data.R
+++ b/View/lib/R/shiny/lib/mbiome/mbiome-data.R
@@ -63,8 +63,8 @@ MicrobiomeData <- R6Class("MicrobiomeData",
          get_otus_by_level = function(taxonomy_level=NULL){
            self$otu_table$get_otus_by_level(taxonomy_level)
          },
-         get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T, removeZeros=F){
-            self$otu_table$get_top_n_by_median(taxonomy_level, n, add_other, removeZeros)
+         get_top_n_by_method = function(taxonomy_level=NULL, n=10, ranking_method = "Median", add_other=T, removeZeros=F){
+            self$otu_table$get_top_n_by_method(taxonomy_level, n, ranking_method, add_other, removeZeros)
          },
          get_top_n_by_mean = function(taxonomy_level=NULL, n=10, add_other=T){
             self$otu_table$get_top_n_by_mean(taxonomy_level, n, add_other)

--- a/View/lib/R/shiny/lib/mbiome/otu-table.R
+++ b/View/lib/R/shiny/lib/mbiome/otu-table.R
@@ -7,7 +7,8 @@ OTUClass <- R6Class("OTUClass",
       use_relative_abundance = T,
       ordered_n_otu = NULL,
       ordered_all_otu = NULL,
-      sample_names = NULL
+      sample_names = NULL,
+      summarized_ranked = NULL
     ),
 
     public = list(
@@ -56,11 +57,9 @@ OTUClass <- R6Class("OTUClass",
         # end of workaroud for perfomance
         colnames(private$summarized_otu)<-c("SampleName", selected_levels, "Abundance")
 
-        private$summarized_medians<-private$summarized_otu[, list(Abundance=median(Abundance), Q3 = quantile(Abundance, 0.75), Max=max(Abundance)), by=taxonomy_level]
-        setorderv(private$summarized_medians, c("Abundance", "Q3", "Max", taxonomy_level), c(-1,-1, -1, rep(1,length(taxonomy_level))))
 
-        private$summarized_means<-private$summarized_otu[,list(Abundance=mean(Abundance)), by=taxonomy_level]
-        setorderv(private$summarized_means, c("Abundance", taxonomy_level), c(-1,rep(1,length(taxonomy_level))))
+        private$summarized_medians<-private$summarized_otu[, list(Abundance=median(Abundance)), by=taxonomy_level]
+        setorderv(private$summarized_medians, c("Abundance", taxonomy_level), c(-1, rep(1,length(taxonomy_level))))
         
         private$ordered_all_otu <- private$summarized_medians[[taxonomy_level]]
 
@@ -117,7 +116,7 @@ OTUClass <- R6Class("OTUClass",
           private$ordered_all_otu
         }else{
           if(n != length(private$ordered_n_otu)){
-            top_n <- head(private$summarized_medians, n)
+            top_n <- head(private$summarized_ranked, n)
             private$ordered_n_otu <- top_n[[private$last_taxonomy]]
           }
           private$ordered_n_otu
@@ -132,13 +131,32 @@ OTUClass <- R6Class("OTUClass",
         }
       },
 
-      get_top_n_by_median = function(taxonomy_level=NULL, n=10, add_other=T, removeZeros=F){
+      get_top_n_by_method = function(taxonomy_level=NULL, n=10, ranking_method = "Median", add_other=T, removeZeros=F){
+        
         if(!is.null(taxonomy_level) & !identical(taxonomy_level, private$last_taxonomy)){
           self$reshape(taxonomy_level = taxonomy_level)
         }
 
-        top_n <- head(private$summarized_medians, n)
+        if(identical(ranking_method, "Median")){
+          private$summarized_ranked <- private$summarized_otu[, list(Abundance=median(Abundance)), by=taxonomy_level]
+        } else if(identical(ranking_method,"Maximum")) {
+          private$summarized_ranked <- private$summarized_otu[, list(Abundance=max(Abundance)), by=taxonomy_level]
+        } else if(identical(ranking_method, "Third quartile")) {
+          private$summarized_ranked <- private$summarized_otu[, list(Abundance=quantile(Abundance, 0.75)), by=taxonomy_level]
+        } else if(identical(ranking_method, "Variance")) {
+          private$summarized_ranked <- private$summarized_otu[, list(Abundance=var(Abundance)), by=taxonomy_level]
+        } else {
+          private$summarized_ranked <- NULL
+        }
 
+        
+        setorderv(private$summarized_ranked, c("Abundance", taxonomy_level), c(-1, rep(1,length(taxonomy_level))))
+
+
+        print(private$summarized_ranked)
+        top_n <- head(private$summarized_ranked, n)
+
+        
         if(removeZeros) {
           top_n <- top_n[Abundance>0, ]
         }
@@ -156,6 +174,8 @@ OTUClass <- R6Class("OTUClass",
           setcolorder(grouped_dt, colnames(filtered_ten))
           filtered_ten <- rbindlist(list(filtered_ten,  grouped_dt))
         }
+
+
         filtered_ten
       },
 

--- a/View/lib/R/shiny/lib/mbiome/otu-table.R
+++ b/View/lib/R/shiny/lib/mbiome/otu-table.R
@@ -59,10 +59,9 @@ OTUClass <- R6Class("OTUClass",
         private$summarized_medians<-private$summarized_otu[, list(Abundance=median(Abundance), Q3 = quantile(Abundance, 0.75), Max=max(Abundance)), by=taxonomy_level]
         setorderv(private$summarized_medians, c("Abundance", "Q3", "Max", taxonomy_level), c(-1,-1, -1, rep(1,length(taxonomy_level))))
 
-        private$summarized_medians<-private$summarized_otu[,list(Abundance=median(Abundance)), by=taxonomy_level]
         private$summarized_means<-private$summarized_otu[,list(Abundance=mean(Abundance)), by=taxonomy_level]
-
         setorderv(private$summarized_means, c("Abundance", taxonomy_level), c(-1,rep(1,length(taxonomy_level))))
+        
         private$ordered_all_otu <- private$summarized_medians[[taxonomy_level]]
 
         self

--- a/View/lib/R/shiny/lib/mbiome/otu-table.R
+++ b/View/lib/R/shiny/lib/mbiome/otu-table.R
@@ -56,11 +56,12 @@ OTUClass <- R6Class("OTUClass",
         # end of workaroud for perfomance
         colnames(private$summarized_otu)<-c("SampleName", selected_levels, "Abundance")
 
-        private$summarized_medians<-private$summarized_otu[,list(Abundance=median(Abundance)), by=taxonomy_level]
+        private$summarized_medians<-private$summarized_otu[, list(Abundance=median(Abundance), Q3 = quantile(Abundance, 0.75), Max=max(Abundance)), by=taxonomy_level]
+        setorderv(private$summarized_medians, c("Abundance", "Q3", "Max", taxonomy_level), c(-1,-1, -1, rep(1,length(taxonomy_level))))
 
+        private$summarized_medians<-private$summarized_otu[,list(Abundance=median(Abundance)), by=taxonomy_level]
         private$summarized_means<-private$summarized_otu[,list(Abundance=mean(Abundance)), by=taxonomy_level]
 
-        setorderv(private$summarized_medians, c("Abundance", taxonomy_level), c(-1,rep(1,length(taxonomy_level))))
         setorderv(private$summarized_means, c("Abundance", taxonomy_level), c(-1,rep(1,length(taxonomy_level))))
         private$ordered_all_otu <- private$summarized_medians[[taxonomy_level]]
 


### PR DESCRIPTION
Previously we ordered by median and removed any taxa with median relative abundance=0. However, seeing only a few taxa suggests to the user that no others exist, which is not true.

**This PR fixes the above issue by ranking taxa by median, then third quartile, then maximum value.** See lines 59-60 of `otu-table.R`. 

Additionally, this PR adds the following features:
- Informational text that describes the ranking function
- Above help text is available only when no metadata is selected.
- Table of statistics is hidden when no metadata is selected.