### PR TITLE
Correlation app updates

### DIFF
--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -27,7 +27,7 @@ shinyServer(function(input, output, session) {
   column_y<-NULL
   hash_colors <- NULL
   max_point_size = 10
-  plot_margin <- 60
+  plot_margin <- 100
 
   # variables to define some plot parameters
   NUMBER_TAXA <- 10
@@ -189,16 +189,17 @@ shinyServer(function(input, output, session) {
       if(nrow(result)>0){
 
        
-        chart<-ggplot(result, aes_string(x=cols[2], y=cols[1]))+
-            geom_point(aes_string(color="rho", size="size"))+
+chart<-ggplot(result, aes_string(x=cols[2], y=cols[1]))+
+            geom_point(aes_string(size="size", colour ="rho"))+
             scale_size(range = c(1, max_point_size), guide = 'none')+
-            theme_eupath_default(legend.position = "bottom")+
-            scale_colour_gradient2()+
-            labs(x="Sample Details", y=taxon_level, color="Spearman rho")+
+            theme_eupath_default()+
+            scale_colour_gradient2(high="#d8b365", mid="#f0f0f0", low="#5ab4ac")+
+            scale_y_discrete(limits = rev(as.character(unique(result[[cols[1]]]))))+
+            labs(x="Sample Details", y=taxon_level, colour="Spearman rho")+
             guides(colour = guide_colourbar(title.position="top", title.hjust = 0.5))+
             theme(panel.border = element_blank(), panel.grid.major = element_blank(),
-              panel.grid.minor = element_blank(), axis.line = element_line(colour = "black"))
-
+              panel.grid.minor = element_blank(), axis.line = element_line(colour = "black"), legend.position = "top")+
+            theme(axis.text.x = element_text(angle = 45, vjust = 0.5, hjust=1))
 
        #  }else{
         #   chart<-ggplot(result, aes_string(x=cols[2], y=cols[1], fill= "rho"))+
@@ -213,23 +214,23 @@ shinyServer(function(input, output, session) {
         ggplot_build_object <<- chart
 
         output$plotWrapper<-renderPlotly({
-          ggplotly(chart) %>% plotly:::config(displaylogo = FALSE)
+          ggplotly(chart, height=37400) %>% layout(xaxis=list(side="top")) %>% plotly:::config(displaylogo = FALSE)
         })
 
         # NEW!
         quantity_samples <- uniqueN(result[[taxon_level]])
         logjs(quantity_samples)
 
-        if(quantity_samples<MAX_SAMPLES_NO_RESIZE){
-          result_to_show<-plotlyOutput("plotWrapper",
-             width = "100%", height = "500px"
-           )
-        }else{
+        #if(quantity_samples<MAX_SAMPLES_NO_RESIZE){
+        #  result_to_show<-plotlyOutput("plotWrapper",
+        #     width = "100%", height = "500px"
+        #   )
+        #}else{
           result_to_show<-plotlyOutput("plotWrapper",
             width = "100%",
             height = paste0(quantity_samples*max_point_size*4 + plot_margin,"px")
           )
-        }
+        #}
         cols_to_show<-result[, !"size", with=FALSE]
         # output$datatableOutput<-renderDataTable(cols_to_show)
       }else{

--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -26,6 +26,8 @@ shinyServer(function(input, output, session) {
   column_x<-NULL
   column_y<-NULL
   hash_colors <- NULL
+  max_point_size = 10
+  plot_margin <- 60
 
   # variables to define some plot parameters
   NUMBER_TAXA <- 10
@@ -186,7 +188,7 @@ shinyServer(function(input, output, session) {
 
       if(nrow(result)>0){
 
-       max_point_size = 10
+       
         chart<-ggplot(result, aes_string(x=cols[2], y=cols[1]))+
             geom_point(aes_string(color="rho", size="size"))+
             scale_size(range = c(1, max_point_size), guide = 'none')+
@@ -214,8 +216,8 @@ shinyServer(function(input, output, session) {
           ggplotly(chart) %>% plotly:::config(displaylogo = FALSE)
         })
 
-        # This is not the number of samples...no?
-        quantity_samples<-nrow(result)
+        # NEW!
+        quantity_samples <- uniqueN(result[[taxon_level]])
         logjs(quantity_samples)
 
         if(quantity_samples<MAX_SAMPLES_NO_RESIZE){
@@ -225,7 +227,7 @@ shinyServer(function(input, output, session) {
         }else{
           result_to_show<-plotlyOutput("plotWrapper",
             width = "100%",
-            height = quantity_samples*max_point_size*4
+            height = paste0(quantity_samples*max_point_size*4 + plot_margin,"px")
           )
         }
         cols_to_show<-result[, !"size", with=FALSE]

--- a/View/lib/R/shiny/apps/correlation_app/ui.R
+++ b/View/lib/R/shiny/apps/correlation_app/ui.R
@@ -1,4 +1,4 @@
-# Declaring the packages
+
 library(shiny)
 library(shinyjs)
 
@@ -45,17 +45,17 @@ shinyUI(
             style="padding-left: 2.2em;",
             fluidRow(
               strong("Visualization type")
-            ),
-            fluidRow(
-              div(
-                style = "padding-top: 0.65em;",
-                radioButtons("plotTypeRadio",
-                             label=NULL,
-                             choices = c("Dot plot" = "dotplot",
-                                         "Heatmap" = "heatmap"),
-                             selected = c("dotplot"), inline=T)
-              )
             )
+            # fluidRow(
+            #   div(
+            #     style = "padding-top: 0.65em;",
+            #     radioButtons("plotTypeRadio",
+            #                  label=NULL,
+            #                  choices = c("Dot plot" = "dotplot",
+            #                              "Heatmap" = "heatmap"),
+            #                  selected = c("dotplot"), inline=T)
+            #   )
+            # )
           )
         ) ),
          column(3,
@@ -76,35 +76,38 @@ shinyUI(
             )
           )
          ), # end fluidRow toolbar
-        fluidRow(
-          column(12,
-            uiOutput("pvalueCutoff"),
-            tags$style(type="text/css", "#pvalueCutoff {height:10px;}")
-          )
-        ),
+        # fluidRow(
+        #   column(12,
+        #     div(style = "height:40px",
+        #       uiOutput("pvalueCutoff"),
+        #       tags$style(type="text/css", "#pvalueCutoff {height:10px;}")
+        #     )
+        #   )
+        # ),
            div(id="chartLoading", style="text-align: center;",
                h5("Calculating correlation. This could take a while..."),
                img(src = "spinner.gif", id = "loading-spinner")
            ),
            div(
-             id="divContent",
+             id="divContent", style="text-align: center;",
                fluidRow(column(
                  12,
                  div(
                   uiOutput("correlationChart"),
                   uiOutput("hover_info")
                 )
-               )),
+               ))
                # fluidRow(column(
                #   12,
                #   HTML("<span class='hint--bottom  hint--rounded' aria-label='We have rounded corners for you'>Hmm...So you don't like sharp edges?</span>")
                # )),
-               fluidRow(column(
-                 12,
-                   dataTableOutput("datatableOutput")
-               ))
+              #  fluidRow(column(
+              #    12,
+              #      dataTableOutput("datatableOutput")
+              #  ))
             ) # end divContent
     ) # end div id = "app-content",
     ) # end hidden
   ) # end fluidPage
 ) # end shinyUI
+

--- a/View/lib/R/shiny/apps/correlation_app/ui.R
+++ b/View/lib/R/shiny/apps/correlation_app/ui.R
@@ -39,25 +39,9 @@ shinyUI(
            4,
            uiOutput("corType")
          ),
-         hidden(
-         column(3,
-          div(
-            style="padding-left: 2.2em;",
-            fluidRow(
-              strong("Visualization type")
-            )
-            # fluidRow(
-            #   div(
-            #     style = "padding-top: 0.65em;",
-            #     radioButtons("plotTypeRadio",
-            #                  label=NULL,
-            #                  choices = c("Dot plot" = "dotplot",
-            #                              "Heatmap" = "heatmap"),
-            #                  selected = c("dotplot"), inline=T)
-            #   )
-            # )
-          )
-        ) ),
+        column(2,
+          actionButton("go", style="margin-top: 25px; font-weight: bolder; border-color: blue; color: blue;", label = "Run Analysis")
+        ),
          column(3,
             div(
               # style = "padding-left: 0.1em;",
@@ -76,14 +60,6 @@ shinyUI(
             )
           )
          ), # end fluidRow toolbar
-        # fluidRow(
-        #   column(12,
-        #     div(style = "height:40px",
-        #       uiOutput("pvalueCutoff"),
-        #       tags$style(type="text/css", "#pvalueCutoff {height:10px;}")
-        #     )
-        #   )
-        # ),
            div(id="chartLoading", style="text-align: center;",
                h5("Calculating correlation. This could take a while..."),
                img(src = "spinner.gif", id = "loading-spinner")
@@ -101,11 +77,14 @@ shinyUI(
                #   12,
                #   HTML("<span class='hint--bottom  hint--rounded' aria-label='We have rounded corners for you'>Hmm...So you don't like sharp edges?</span>")
                # )),
-              #  fluidRow(column(
-              #    12,
-              #      dataTableOutput("datatableOutput")
-              #  ))
-            ) # end divContent
+              fluidRow(column(
+                12,
+                   dataTableOutput("datatableOutput")
+              ))
+            ), # end divContent
+            div(id="noPlot", syle="text-align: center;",
+              h5(class="alert alert-warning","Click Run Analysis to make a new plot")
+            )
     ) # end div id = "app-content",
     ) # end hidden
   ) # end fluidPage

--- a/View/lib/R/shiny/apps/correlation_app/ui.R
+++ b/View/lib/R/shiny/apps/correlation_app/ui.R
@@ -72,12 +72,12 @@ shinyUI(
                   uiOutput("correlationChart"),
                   uiOutput("hover_info")
                 )
-               ))
+               )),
                # fluidRow(column(
                #   12,
                #   HTML("<span class='hint--bottom  hint--rounded' aria-label='We have rounded corners for you'>Hmm...So you don't like sharp edges?</span>")
                # )),
-              fluidRow(column(
+             fluidRow(column(
                 12,
                    dataTableOutput("datatableOutput")
               ))

--- a/View/lib/R/shiny/apps/correlation_app/ui.R
+++ b/View/lib/R/shiny/apps/correlation_app/ui.R
@@ -40,7 +40,7 @@ shinyUI(
            uiOutput("corType")
          ),
         column(2,
-          actionButton("go", style="margin-top: 25px; font-weight: bolder; border-color: blue; color: blue;", label = "Run Analysis")
+          actionButton("go", style="margin-top: 25px; background-color: #4e81bd; color: white; border-style: none;", label = "Run Analysis")
         ),
          column(3,
             div(


### PR DESCRIPTION
# Major updates to correlation app

- Plot sizing issues corrected
- Addition of "Run Analysis" button
- Plotly double-plotting errors circumvented
- Diverging colormap replaced sequential colormap for correlation values
- Plot aesthetics updated
- Large blocks of unused code deleted

## Additional considerations: 
- Using `'heatmaply` for the plot. Decided against using `heatmaply` for a few reasons. First, the original code had the data already nicely prepared for `ggplot`, and the switch to `heatmaply` would have required more effort in data reshaping. Additionally, we can recreate `heatmaply`'s nice aesthetics using a few extra arguments to `theme()` in `ggplot`. Finally, `ggplot` is already installed on the server whereas `heatmaply` would have required a new install.
- Resizing a plot is known in shiny to not work well. More recent package versions have addressed the issue, but for the case of this app we circumvent the issue by separating the action of clearing the plot from that of rendering a new plot. 
- Adding point outlines and modifying the colormap orientation are not allowed, at least in these package versions.
- Mapping from the ggplot point size argument to height in pixels is not straightforward. If one is found, alter the scalar in `rows_in_plot*max_point_size*4`.
- How to manage showing dots when p-value = 0? This maps to dot size = Inf which then does not get displayed at all. This situation is unlikely for most cases of real data, but can happen (for example, Age (days) and Age (years) correlate perfectly). In the future (=EDA), we might be able to more easily assign styling based on data associated with that point (ex. using d3 but probably plotlyjs can, too). In this case, we can give these points max size but color them gray or something so the user sees them but knows there is something special about these points.


## Future features
If time allows, add the following:
- Set colorbar height to a constant, so that it does not stretch with plot size. Hint: look to class "colorbar" and and set properties either with custom js or in `style.css`.
- Report N on the tooltip
- Report p-value on the tooltip.
- This PR does not address previous silent erring issues when `corType="mm"`. Need to fix these in the future.