### PR TITLE
Shiny plot sizing fixes

### DIFF
--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -311,7 +311,7 @@ observeEvent(input$go, {
           
 
           output$plotWrapper<-renderPlotly({
-            ggplotly(chart) %>% layout(xaxis=list(side="top")) %>% plotly:::config(displaylogo = FALSE)
+            ggplotly(chart) %>% layout(xaxis=list(side="top"), margin=list(b=0)) %>% plotly:::config(displaylogo = FALSE)
           })
 
           # Populate and render data table

--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -201,11 +201,10 @@ observeEvent(input$go, {
           )
         } else {
           # Also resize width
-          generated_plot<-plotlyOutput("plotWrapper",
-            width = paste0(cols_in_plot*(max_point_size*4.5)+(max_row_label_width*96)+plot_margin,"px"),
+	  generated_plot<-plotlyOutput("plotWrapper",
+            width = paste0(cols_in_plot*(max_point_size*4.5)+(max_row_label_width*96) + (max(max_col_label_height*96*cos(pi/4) - max_point_size*4.5, 0)) + plot_margin,"px"),
             height= paste0(rows_in_plot*(max_point_size*4.5)+(max_col_label_height*96*sin(pi/4))+plot_margin,"px")          
           )
-
         }
       }
     } else {

--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -26,8 +26,6 @@ shinyServer(function(input, output, session) {
   column_x<-NULL
   column_y<-NULL
   hash_colors <- NULL
-  max_point_size <- 10
-  plot_margin <- 0
 
   # variables to define some plot parameters
   NUMBER_TAXA <- 10
@@ -196,11 +194,11 @@ observeEvent(input$go, {
       col_label_overhang <- (max(max_col_label_length*96*cos(pi/4) - 0.5*MAX_POINT_SIZE*POINT_SIZE_SCALE_FACTOR, 0))
       col_label_height <- max_col_label_length*96*sin(pi/4)    
       
-      # plot_width = (width of x-axis) + (width of row labels in px) + (overhang from angled column labels) + margin
-      plot_width <- (cols_in_plot*col_width) + max_row_label_width + col_label_overhang + plot_margin
+      # plot_width = (width of x-axis) + (width of row labels in px) + (overhang from angled column labels)
+      plot_width <- (cols_in_plot*col_width) + max_row_label_width + col_label_overhang
 
-      # plot_height = (height of y-axis) + (height of column lables accounting for angle) + margin
-      plot_height <- (rows_in_plot*row_height) + col_label_height + plot_margin
+      # plot_height = (height of y-axis) + (height of column lables accounting for angle)
+      plot_height <- (rows_in_plot*row_height) + col_label_height
 
       generated_plot <- plotlyOutput("plotWrapper", 
           width = paste0(plot_width, 'px'),
@@ -281,7 +279,7 @@ observeEvent(input$go, {
 
           chart<-ggplot(result, aes_string(x=cols[2], y=cols[1]))+
               geom_point(aes(size = log10(0.5+1/pvalue), colour =rho))+
-              scale_size(range = c(1, max_point_size), guide = 'none')+
+              scale_size(range = c(1, MAX_POINT_SIZE), guide = 'none')+
               theme_eupath_default()+
               scale_colour_gradient2(high="#d8b365", mid="#f0f0f0", low="#5ab4ac", limits=c(-1,1))+
               scale_y_discrete(limits = stringr::str_sort(as.character(unique(result[[cols[1]]])), decreasing=T))+

--- a/View/lib/R/shiny/apps/correlation_app/server.R
+++ b/View/lib/R/shiny/apps/correlation_app/server.R
@@ -27,12 +27,12 @@ shinyServer(function(input, output, session) {
   column_y<-NULL
   hash_colors <- NULL
   max_point_size <- 10
-  plot_margin <- 200
+  plot_margin <- 30
 
   # variables to define some plot parameters
   NUMBER_TAXA <- 10
-  MAX_SAMPLES_NO_RESIZE <- 7
-  MAX_METADATA_NO_RESIZE <- 7
+  MAX_SAMPLES_NO_RESIZE <- 2
+  MAX_METADATA_NO_RESIZE <- 2
   MIN_HEIGHT_AFTER_RESIZE <- 12
 
   NO_METADATA_SELECTED <- "No Metadata Selected"
@@ -187,7 +187,7 @@ observeEvent(input$go, {
         } else {
           # Reseize width
             generated_plot<-plotlyOutput("plotWrapper",
-              width = paste0(cols_in_plot*max_point_size*4+plot_margin,"px"), height = "700px"
+	      width = paste0(cols_in_plot*(max_point_size*4.5)+(max_row_label_width*96)+plot_margin,"px"), height = "700px"
             )
         } # end if cols_in_plot < MAX
 
@@ -197,13 +197,13 @@ observeEvent(input$go, {
         if(cols_in_plot<MAX_METADATA_NO_RESIZE) {
           generated_plot<-plotlyOutput("plotWrapper",
             width = "700px",
-            height=paste0(rows_in_plot*max_point_size*4+plot_margin,"px")
+            height=paste0(rows_in_plot*(max_point_size*4.5)+(max_col_label_height*96*sin(pi/4))+plot_margin,"px")
           )
         } else {
           # Also resize width
           generated_plot<-plotlyOutput("plotWrapper",
-            width = paste0(cols_in_plot*max_point_size*4+plot_margin,"px"),
-            height=paste0(rows_in_plot*max_point_size*4+plot_margin,"px")
+            width = paste0(cols_in_plot*(max_point_size*4.5)+(max_row_label_width*96)+plot_margin,"px"),
+            height= paste0(rows_in_plot*(max_point_size*4.5)+(max_col_label_height*96*sin(pi/4))+plot_margin,"px")          
           )
 
         }
@@ -297,15 +297,18 @@ observeEvent(input$go, {
           # Calculate the number of rows in the resulting plot for later plot sizing.
           if(identical(cor_type, "tm")){
             rows_in_plot <<- uniqueN(result[[taxon_level]])
+	    max_row_label_width <<- max(unlist(lapply(result[[taxon_level]], strwidth, units="in")))
+            
             cols_in_plot <<- uniqueN(result[, metadata])
+            max_col_label_height <<- max(unlist(lapply(result[, metadata], strwidth, units="in")))
           } else if(identical(cor_type, "mm")) {
             rows_in_plot <<- uniqueN(result[, metadata.1])
+            max_row_label_width <<- max(unlist(lapply(result[, metadata.1], strwidth, units="in")))
+            
             cols_in_plot <<- uniqueN(result[, metadata.1])
+            max_col_label_height <<- max_row_label_width
           }
 
-          # Calculate new plot height. Not exact because I'm unsure of the map from max_point_size as a ggpplot input to circle diameter in the output svg.
-          new_height <- rows_in_plot*max_point_size*4
-          chart$height <- new_height
           
 
           output$plotWrapper<-renderPlotly({

--- a/View/lib/R/shiny/apps/correlation_app/ui.R
+++ b/View/lib/R/shiny/apps/correlation_app/ui.R
@@ -78,6 +78,7 @@ shinyUI(
                #   HTML("<span class='hint--bottom  hint--rounded' aria-label='We have rounded corners for you'>Hmm...So you don't like sharp edges?</span>")
                # )),
              fluidRow(column(
+                style='padding-top:40px',
                 12,
                    dataTableOutput("datatableOutput")
               ))


### PR DESCRIPTION
## Goal
The correlation app plot size changes based on length of x and y tick labels, changing the aspect ratio. While this behavior is expected, the correlegram output is easiest read when the aspect ratio between the x and y axes is 1. Occasionally current sizing strategy even cuts off long tick labels. 

## Updates
This PR improves the plot sizing logic for the correlation app. Side effect updates include modifying whitespace.

## Strategy
The height and width of the plot are now calculated explicitly. The calculation was made slightly more complicated because of the angled column labels. In particular, 
`height = y-axis height + max column label height`
`height = (row height * number of rows) + (max column label length *sin(pi/4))`

and 

`width = x-axis width + max row label width  + overhang from angled column labels`
`width = (column width * number of columns) + max row label width + max( max col label length * cos(pi/4) - 0.5 * column width, 0)`

in pixels. The length of strings was calculated with `strwidth`.

The above strategy works best for data with a large number of columns, rows. 

## Notes
- I also tried to use `coord_fixed(ratio=1)` from [ggplot2](https://ggplot2.tidyverse.org/reference/coord_fixed.html). This approach led to odd whitespace in both axes that I could not figure out. This would have been the easiest and simplest solution. Not sure if the breakdown is in ggplot2, ggplotly, or in shiny rendering plotly.
- The app will err if the plot width or height is too small. The lower bound is unclear, so we treat results with number of rows/cols < 3 as a special case. 
- The calculation of the column label overhang is imprecise and errs on too large, since the last label is not necessarily longest. Alternatively, we could use the length of the last column label in that overhang calculation. Using the last column label will err on the side of too small if the second-to-last label is longer than the last. I picked erring on having a plot that is slightly too wide instead of too thin to at least allow the plot to be readable and prevent overlapping points. 
- Even the above implementation is not perfect. One of ggplot, plotly, shiny does some automatic scaling that I could not always account for. For example, sometimes the y-axis label will be further left than the start of all y-axis tick labels, and other times it is not. Any advice on this is appreciated!
- Also tried to set `autosize = F` in `layout`, but this also produced odd results. 
- These fixes do NOT address the colorbar sizing.