### PR TITLE
order sample_dt by SampleName to match otu_dt

### DIFF
--- a/View/lib/R/shiny/lib/mbiome/mbiome-data.R
+++ b/View/lib/R/shiny/lib/mbiome/mbiome-data.R
@@ -9,9 +9,10 @@ MicrobiomeData <- R6Class("MicrobiomeData",
          initialize = function(otu_table = NA, sample_table = NA) {
            self$otu_table <- otu_table
            self$sample_table <- sample_table
-           
+          
            sample_from_metadata <- self$sample_table$get_sample_names()
            sample_from_taxa <- self$otu_table$get_sample_names()
+            
            
            if(isTRUE(all.equal(sample_from_metadata,sample_from_taxa))){
              private$common_samples <- sample_from_taxa

--- a/View/lib/R/shiny/lib/mbiome/sample-table.R
+++ b/View/lib/R/shiny/lib/mbiome/sample-table.R
@@ -9,6 +9,10 @@ SampleClass <- R6Class("SampleClass",
         sample_dt = NULL,
         initialize = function(sample_dt = NA) {
           
+          # Sort sample data table alphabetically by sample name
+          sample_dt <- sample_dt %>% arrange(SampleName)
+          sample_dt <- as.data.table(sample_dt)         
+ 
           self$sample_dt <- sample_dt
           private$sample_names <- unique(sample_dt$SampleName)
           


### PR DESCRIPTION
* See also https://github.com/VEuPathDB/MicrobiomeWebsite/pull/19*
## Issue
A user dataset broke all shiny apps and produced the error
```
  78: stop
  77: dcast.data.table
  75: self$sample_table$get_metadata_as_column
  74: mstudy$get_metadata_as_column
  73: mbiome2phyloseq
  72: observeEventHandler [/var/www/MicrobiomeDB/mbio.b23/gus_home/lib/R/View/shiny/apps/beta_diversity/server.R#141]
```
After investigating, we learned that the sample detail table sample_dt (from Characteristics.tab) and the otu table otu_dt are assumed by mbiome-data.R to have the same order of Sample names (see lines 13-31), and that this ordering is alphabetical (a product of otu-table.R line 18).
The user's dataset had identical ordering of the sample names, but this ordering was not alphabetical, which caused the error.

## Fix
Order the sample_dt table alphabetically by Sample name as soon as it is read in.