### PR TITLE
reorganize to allow coreUI theming

### DIFF
--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
@@ -9,7 +9,7 @@ import { colors } from '@veupathdb/coreui';
 import { useCoreUIFonts } from '@veupathdb/coreui/dist/hooks';
 
 export function Page(DefaultComponent: React.ComponentType<Props>) {
-  return function MicrbobiomePage(props: Props) {
+  return function MicrobiomePage(props: Props) {
     // useAttemptActionClickHandler();
     useCoreUIFonts();
 

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Props } from '@veupathdb/wdk-client/lib/Components/Layout/Page';
+
+// import { useAttemptActionClickHandler } from '@veupathdb/study-data-access/lib/data-restriction/dataRestrictionHooks';
+
+import UIThemeProvider from '@veupathdb/coreui/dist/components/theming/UIThemeProvider';
+import { colors } from '@veupathdb/coreui';
+import { useCoreUIFonts } from '@veupathdb/coreui/dist/hooks';
+
+export function Page(DefaultComponent: React.ComponentType<Props>) {
+  return function MicrbobiomePage(props: Props) {
+    // useAttemptActionClickHandler();
+    useCoreUIFonts();
+
+    return (
+           <UIThemeProvider
+              theme={{
+                palette: {
+                  primary: { hue: colors.mutedBlue, level: 600 },
+                  secondary: { hue: colors.mutedRed, level: 500 },
+                },
+              }}
+            >
+              <DefaultComponent {...props} />
+            </UIThemeProvider>
+    );
+  };
+}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/Page.tsx
@@ -17,7 +17,7 @@ export function Page(DefaultComponent: React.ComponentType<Props>) {
            <UIThemeProvider
               theme={{
                 palette: {
-                  primary: { hue: colors.mutedBlue, level: 600 },
+                  primary: { hue: colors.mutedBlue, level: 500 },
                   secondary: { hue: colors.mutedRed, level: 500 },
                 },
               }}

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/index.js
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/index.js
@@ -8,7 +8,7 @@ import { menuItemsFromSocials, iconMenuItemsFromSocials } from '@veupathdb/web-c
 import { StudyMenuItem } from '@veupathdb/web-common/lib/App/Studies';
 import logoUrl from 'site/images/18170.png';
 import heroImageUrl from 'site/images/mbio_hero.png';
-import vizData from './visualizations.json';
+import vizData from '../visualizations.json';
 import { STATIC_ROUTE_PATH } from '@veupathdb/web-common/lib/routes';
 
 import { StudyCard } from '@veupathdb/web-common/lib/App/Studies';

--- a/Site/webapp/wdkCustomization/js/client/component-wrappers/index.js
+++ b/Site/webapp/wdkCustomization/js/client/component-wrappers/index.js
@@ -17,6 +17,8 @@ import { ImageCard } from '@veupathdb/web-common/lib/App/ImageCard';
 
 import { studyMatchPredicate, studyFilters } from '@veupathdb/web-common/lib/util/homeContent';
 
+import { Page } from './Page';
+
 export default {
   SiteHeader: () => SiteHeader,
   IndexController: () => IndexController,
@@ -26,7 +28,8 @@ export default {
     : <DefaultComponent {...props }/>,
   AnswerController: DefaultComponent => props => props.ownProps.recordClass === 'dataset'
     ? <StudyAnswerController {...props} DefaultComponent={DefaultComponent} />
-    : <DefaultComponent {...props }/>
+    : <DefaultComponent {...props }/>,
+  Page
 }
 
 function SiteFooter() {

--- a/Site/webapp/wdkCustomization/js/client/main.js
+++ b/Site/webapp/wdkCustomization/js/client/main.js
@@ -4,7 +4,7 @@ import { edaServiceUrl } from '@veupathdb/web-common/lib/config';
 
 import '@veupathdb/web-common/lib/styles/client.scss';
 
-import componentWrappers from './componentWrappers';
+import componentWrappers from './component-wrappers';
 import wrapStoreModules from './wrapStoreModules';
 import { wrapRoutes } from './routes';
 import { wrapWdkDependencies } from '@veupathdb/study-data-access/lib/shared/wrapWdkDependencies';


### PR DESCRIPTION
Resolves #25 

The goal of this PR is to enable CoreUI theming on the mbio eda site. The current implementation strategy is to simply replicate clinepi's strategy by using a wrapped `Page` component.

Since clinepi has lots of component wrappers, i'm guessing mbio will soon, too. So, I went ahead and made a `component-wrappers` folder and moved the previous `componentWrappers.js` file here.

Check out my dev site, or see screen shot below (specifically look at button coloring)
<img width="1784" alt="Screen Shot 2022-03-28 at 5 05 13 PM" src="https://user-images.githubusercontent.com/11710234/160487710-a179a300-4248-475a-b792-c9bd5253e606.png">

